### PR TITLE
fix: overlay zlib to build on macos/arm64

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -30,9 +30,6 @@ tasks:
     - "--test_tag_filters=-nomacos"
     test_targets:
     - "..."
-    - "-//internal/e2e/override_repository:override_repository_test"
-    - "-//internal/e2e/many_dirs:many_dirs"
-    - "-//internal/e2e/symlink_dir:symlink_dir_test"
   macos_legacy_watcher:
     platform: macos
     build_flags:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,20 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "zlib",
+    build_file = "//:third_party/zlib/BUILD.zlib",
+    patch_args = [ "-p1" ],
+    patches = [
+        "//:third_party/zlib/shuffle-apple-defs-for-m1.patch",
+    ],
+    sha256 = "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff",
+    strip_prefix = "zlib-1.2.11",
+    urls = [
+        "https://github.com/madler/zlib/archive/refs/tags/v1.2.11.tar.gz",
+    ],
+)
+
+http_archive(
     name = "bazel_skylib",
     sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
     urls = [

--- a/third_party/zlib/BUILD.zlib
+++ b/third_party/zlib/BUILD.zlib
@@ -1,0 +1,63 @@
+# Copied from https://github.com/protocolbuffers/protobuf/blob/master/third_party/zlib.BUILD
+# Via https://github.com/bazelbuild/bazel-federation/blob/master/third_party/zlib.BUILD
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+_ZLIB_HEADERS = [
+    "crc32.h",
+    "deflate.h",
+    "gzguts.h",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.h",
+    "inftrees.h",
+    "trees.h",
+    "zconf.h",
+    "zlib.h",
+    "zutil.h",
+]
+
+_ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_HEADERS]
+
+# In order to limit the damage from the `includes` propagation
+# via `:zlib`, copy the public headers to a subdirectory and
+# expose those.
+genrule(
+    name = "copy_public_headers",
+    srcs = _ZLIB_HEADERS,
+    outs = _ZLIB_PREFIXED_HEADERS,
+    cmd = "cp $(SRCS) $(@D)/zlib/include/",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+        # Include the un-prefixed headers in srcs to work
+        # around the fact that zlib isn't consistent in its
+        # choice of <> or "" delimiter when including itself.
+    ] + _ZLIB_HEADERS,
+    hdrs = _ZLIB_PREFIXED_HEADERS,
+    copts = [
+        "-Wno-unused-variable",
+        "-Wno-implicit-function-declaration",
+    ],
+    includes = ["zlib/include/"],
+)

--- a/third_party/zlib/shuffle-apple-defs-for-m1.patch
+++ b/third_party/zlib/shuffle-apple-defs-for-m1.patch
@@ -1,0 +1,24 @@
+--- zlib/zutil.h	2016-12-31 23:37:10
++++ zlib/zutil.h	2025-04-04 10:21:59
+@@ -130,7 +130,9 @@
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#ifdef __APPLE__
++#  define OS_CODE 19
++#elif defined(MACOS) || defined(TARGET_OS_MAC)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+@@ -159,10 +161,6 @@
+ #  define OS_CODE 18
+ #endif
+ 
+-#ifdef __APPLE__
+-#  define OS_CODE 19
+-#endif
+-
+ #if defined(_BEOS_) || defined(RISCOS)
+ #  define fdopen(fd,mode) NULL /* No fdopen() */
+ #endif


### PR DESCRIPTION
In the build of `bazel-watcher` in the target branch, the `lib` library shows a link error on macOS/arm64 as shown below.

Unsure why this is now failing, I think we may need to carry this patch for a few revs until lib is updated.  Since lib is now in BCR, we may be able to fix after @janwinkler1 bzlmod-ification.  The fact that `bazel_tools` is referring to the lib means I've put it fairly early in the WORKSPACE file.

Root cause seems to be that Apple / MacOS are checked in two place, not mutually-exclusive. 